### PR TITLE
fix: break when the character is multibyte

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,15 +32,23 @@ func (t *replacer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err e
 	if len(_src) == 0 && atEOF {
 		return
 	}
-	if !utf8.Valid(_src) {
-		// If not a string, do not process
-		err = ErrInvalidUTF8
-		return
-	}
 
 	for len(_src) > 0 {
-		_, n := utf8.DecodeRune(_src)
-		buf := _src[:n]
+		r, size := utf8.DecodeRune(_src)
+		if r < utf8.RuneSelf {
+			size = 1
+		} else {
+			if size == 1 {
+				// All valid runes of size 1 (those below utf8.RuneSelf) were
+				// handled above. We have invalid UTF-8, or we haven't seen the
+				// full character yet.
+				if !atEOF && !utf8.FullRune(_src) {
+					err = transform.ErrShortSrc
+					break
+				}
+			}
+		}
+		buf := _src[:size]
 		if _, encErr := t.enc.Bytes(buf); encErr != nil {
 			// Replace strings that cannot be converted
 			buf = []byte(string(t.replaceRune))
@@ -54,9 +62,9 @@ func (t *replacer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err e
 		if dstN <= 0 {
 			break
 		}
-		nSrc += n
+		nSrc += size
 		nDst += dstN
-		_src = _src[n:]
+		_src = _src[size:]
 	}
-	return
+	return nDst, nSrc, err
 }


### PR DESCRIPTION
https://github.com/tomtwinkle/garbledreplacer/issues/7

https://github.com/golang/text/blob/6c97a165dd661335ff7bce6104a008558123c353/encoding/encoding.go#L183
↑を参考に、修正案を書いてみました。

4096バイト以上の文字列が渡されたとき、transformerが4096バイト分ずつ文字列を取得してくるようです。（第二引数srcに渡ってくる値はmax 4096byte）

最後の数バイトが文字の途中か途中でないかを判断して処理breakし、次のTransform実行に引き継ぐようにしています。

また、utf8.Validによる判定も不要と判断しています。
長いutf8文字列を4096バイトずつ取得する場合、取得してきたバイト配列をutf-8として読み取れない場合があるからです。

