### PR TITLE
fix: Supports bufio use also for strings larger than 4096 bytes.

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,5 @@
+{
+  "threshold": 0,
+  "ignore": ["**/*_test.go"],
+  "absolute": true
+}

--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 )
 
+//nolint:jscpd
 func TestNewTransformer(t *testing.T) {
 	tests := map[string]struct {
 		encoding  encoding.Encoding

--- a/main_test.go
+++ b/main_test.go
@@ -4,17 +4,17 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
 	"github.com/tomtwinkle/garbledreplacer"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/encoding/traditionalchinese"
 	"golang.org/x/text/transform"
-	"strings"
-	"testing"
-	"unicode/utf8"
 )
 
-//nolint:jscpd
 func TestNewTransformer(t *testing.T) {
 	tests := map[string]struct {
 		encoding  encoding.Encoding


### PR DESCRIPTION
Derived from #7 #8
Resolved the problem that conversion fails for strings of 4096 byte characters or more when bufio is used.